### PR TITLE
Add assert.Panic()

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ API
     func Contains(t *testing.T, expected string, got string, messages ...interface{})
     func NotContains(t *testing.T, unexpected string, got string, messages ...interface{})
     func WithinDuration(t *testing.T, duration time.Duration, goalTime, gotTime time.Time, messages ...interface{})
+    func Panics( t *testing.T, expected interface{}, messages ...interface{} )
 
 Example
 -------

--- a/assert.go
+++ b/assert.go
@@ -141,3 +141,10 @@ func NotContains(t *testing.T, unexpected, got string, messages ...interface{}) 
 func WithinDuration(t *testing.T, duration time.Duration, goalTime, gotTime time.Time, messages ...interface{}) {
 	withinDuration(t, duration, goalTime, gotTime, 1, messages...)
 }
+
+// Uses recover() to check for a panic.
+// Usually used as `defer assert.Panic(expected)`.
+func Panic( t *testing.T, expected interface{}, messages ...interface{} ) {
+	got := recover()
+	equal( t, expected, got, 1, messages... )
+}

--- a/assert_test.go
+++ b/assert_test.go
@@ -101,3 +101,22 @@ func TestWithinDuration(t *testing.T) {
 	// WithinDuration(t, time.Millisecond, now, now.Add(time.Second), "This should blow up")
 	// WithinDuration(t, time.Millisecond, now, now.Add(-time.Second), "This should blow up")
 }
+
+func TestPanic(t *testing.T) {
+	// Simple string
+	func() {
+		defer Panic(t, "Swerve wildly!")
+		panic("Swerve wildly!")
+	}()
+	
+	// Non-string
+	func() {
+		defer Panic(t, 123)
+		panic(123)
+	}()
+	
+	// Everything's cool.
+	func() {
+		defer Panic(t, nil)
+	}()
+}


### PR DESCRIPTION
Hi,
I love this package! I had my own library of asserts; this one does everything it did, and better.

Just one thing is missing, testing for panics. It's basically syntax sugar for `func() { assert.Equal( t, expected, recover() ) }()` You can use it directly in a test function.

```
func TestFooBadArgs( t *testing.T ) {
    defer assert.Panic(t, "These arguments are so bad!")
    Foo("bad arguments")
}()
```

Or do multiple asserts in a single function.

```
func TestCantHack( t *testing.T ) {
    func() {
        defer assert.Panic(t, "Can't hack it!")
        Hack("It")
    }()

    func() {
        defer assert.Panic(t, "Can't hack the Gibson.")
        Hack("Gibson")
    }()
}
```

You can even assert there was no panic... though I'm not sure why you'd do that.

```
func TestEverythingsFine( t *testing.T ) {
    defer assert.Panic(t, nil)
    ...
}
```